### PR TITLE
Added commands for special host-standby backup

### DIFF
--- a/manifests/postgresql.pp
+++ b/manifests/postgresql.pp
@@ -31,6 +31,11 @@
 #   List of databases to dump.
 #   If not defined (an empty array), all databases are dumped
 #
+# [*hotstandby*]
+#   Boolean telling we're on a hot-standby host or not.
+#   Default to false.
+#   More information: http://dba.stackexchange.com/a/30639
+#
 # === Examples
 #
 #   include profiles_common::os::backup::postgresql
@@ -39,6 +44,7 @@ class backup::postgresql (
   $ensure        = present,
   $backup_dir    = '/var/backups/pgsql',
   $backup_format = 'plain',
+  $hotstandby    = false,
   $user          = 'postgres',
   $databases     = [],
   $cron_hour     = 2,

--- a/templates/pgsql-backup.sh.erb
+++ b/templates/pgsql-backup.sh.erb
@@ -17,11 +17,19 @@ DATABASES=$(psql -tc "SELECT datname FROM pg_database WHERE datistemplate = fals
 
 export PGOPTIONS='-c statement_timeout=0'
 
+<% if @hotstandby -%>
+psql -c "SELECT pg_xlog_replay_pause();" -d template1
+<% end -%>
+
 pg_dumpall -U postgres --globals-only |bzip2 > $TMPDIR/ACCOUNT-OBJECTS.$TODAY.dump.bz
 
 for i in $DATABASES; do
   pg_dump -U postgres --format=$BKPFMT --create $i |bzip2  > $TMPDIR/$i.$TODAY.dump.bz
 done
+
+<% if @hotstandby -%>
+psql -c "SELECT pg_xlog_replay_resume();" -d template1
+<% end -%>
 
 # copy main configurations in backup archive
 cp $PG_CONFIG $PG_HBA $TMPDIR


### PR DESCRIPTION
In order to prevent some sync issues, we have to tell postgresql server
"don't update your content for now" before starting the pg_dump command.
Of course, we also need to unlock postgres once the backup is over.