### PR TITLE
Ensure month/day names are always in English

### DIFF
--- a/templates/ldap-backup.sh.erb
+++ b/templates/ldap-backup.sh.erb
@@ -2,8 +2,8 @@
 
 BKPDIR="<%= @backup_dir %>"
 TODAY=$(date +%F)
-DAY=$(date +%A |tr 'A-Z' 'a-z')
-MONTH=$(date +%B |tr 'A-Z' 'a-z')
+DAY=$(LC_TIME= date +%A |tr 'A-Z' 'a-z')
+MONTH=$(LC_TIME= date +%B |tr 'A-Z' 'a-z')
 TMPDIR=$(mktemp -d -p $BKPDIR) || exit 1
 
 /usr/sbin/slapcat -b cn=config > $TMPDIR/config.ldif

--- a/templates/mysql-backup.sh.erb
+++ b/templates/mysql-backup.sh.erb
@@ -22,7 +22,7 @@ fi
 
 case "$1" in
   week)
-    DAY=$(date +%A |tr 'A-Z' 'a-z')
+    DAY=$(LC_TIME= date +%A |tr 'A-Z' 'a-z')
     ;;
   month)
     DAY=$(date +%d)

--- a/templates/pgsql-backup.sh.erb
+++ b/templates/pgsql-backup.sh.erb
@@ -7,8 +7,8 @@ USER="-U <%= @user %>"
 BKPDIR="<%= @backup_dir %>"
 BKPFMT="<%= @backup_format %>"
 TODAY=$(date +%F)
-DAY=$(date +%A |tr 'A-Z' 'a-z')
-MONTH=$(date +%B |tr 'A-Z' 'a-z')
+DAY=$(LC_TIME= date +%A |tr 'A-Z' 'a-z')
+MONTH=$(LC_TIME= date +%B |tr 'A-Z' 'a-z')
 TMPDIR=$(mktemp -d -p $BKPDIR) || exit 1
 <% if !@databases.empty? -%>
 DATABASES="<%= @databases.join(" ") %>"


### PR DESCRIPTION
Avoids problems when backup script is started with another locale.