### PR TITLE
Add backup witness file for monitoring of backup status

### DIFF
--- a/templates/ldap-backup.sh.erb
+++ b/templates/ldap-backup.sh.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 BKPDIR="<%= @backup_dir %>"
 TODAY=$(date +%F)
@@ -18,3 +18,5 @@ if [ $(date +%d) = "01" ]; then
     cp $BKPDIR/ldap_$DAY.tar $BKPDIR/ldap_$MONTH.tar
 fi
 
+# This witness' age will become the age of the last successful backup
+touch $BKPDIR/backup_done_witness

--- a/templates/mysql-backup.sh.erb
+++ b/templates/mysql-backup.sh.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # file managed by puppet
 
 usage() {
@@ -77,3 +77,6 @@ else
   echo "mysqladmin/mysqldump missing. Are you sure this cron must run ?"
   exit 1
 fi
+
+# This witness' age will become the age of the last successful backup
+touch $BKPDIR/backup_done_witness

--- a/templates/pgsql-backup.sh.erb
+++ b/templates/pgsql-backup.sh.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 <% if @container -%>
 PREFIX="docker exec <%= @container %> "
@@ -55,3 +55,5 @@ if [ $(date +%d) = "01" ]; then
     <% end -%>
 fi
 
+# This witness' age will become the age of the last successful backup
+touch $BKPDIR/backup_done_witness


### PR DESCRIPTION
Since it is hard to check if the backup was successful or not, make sure
the script fails if something went wrong and touch a file at the end of
the backup.

So the age of this file is the age of the last successful backup.