### PR TITLE
Allow use of url instead of s3 bucket_name

### DIFF
--- a/manifests/duplicity_s3_item.pp
+++ b/manifests/duplicity_s3_item.pp
@@ -4,11 +4,16 @@ define backup::duplicity_s3_item (
   $rules  = ['+ **'],
 ) {
 
+  $destination = $::backup::duplicity_s3::bucket_name ? {
+    /(^[a-z0-9\+]+:\/\/.*$)/ => $::backup::duplicity_s3::bucket_name,
+    default               => "s3+http://${::backup::duplicity_s3::bucket_name}/${name}",
+  }
+
   duplicity::backup {$name:
     ensure      => $ensure,
     source      => $source,
     rules       => $rules,
-    destination => "s3+http://${::backup::duplicity_s3::bucket_name}/${name}",
+    destination => $destination,
     args        => '--s3-european-buckets --s3-use-new-style',
     env_var     => ["AWS_ACCESS_KEY_ID='${::backup::duplicity_s3::access_key}'",
                     "AWS_SECRET_ACCESS_KEY='${::backup::duplicity_s3::secret_key}'",


### PR DESCRIPTION
duplicity can be use on exoscale by setting destination to `s3://sos.exo.io/<bucketname>/...`

This PR allows to use this kind of URL in bucket name.