### PR TITLE
Fix default mysqldump options

### DIFF
--- a/manifests/mysql.pp
+++ b/manifests/mysql.pp
@@ -23,7 +23,7 @@ class backup::mysql(
   $cron_hour              = '2',
   $cron_minute            = '0',
   $mysqldump_retention    = 'week',
-  $mysqldump_options      = '--all-database --extended-insert',
+  $mysqldump_options      = '--all-databases --extended-insert',
   $mysql_post_backup_hook = undef,
 ) {
 


### PR DESCRIPTION
This removes a warning saying that `option prefix 'all-database' is
error-prone and can break in the future. Please use the full name
'all-databases' instead`.